### PR TITLE
tearDown bugfix

### DIFF
--- a/addon/components/slack-search-input/modifiers/-date/component.js
+++ b/addon/components/slack-search-input/modifiers/-date/component.js
@@ -83,7 +83,9 @@ export default Ember.Component.extend({
   },
 
   tearDown: on('willDestroyElement', function() {
-    this._picker.destroy();
+    if (this._picker) {
+      this._picker.destroy();
+    }
   })
 
 });


### PR DESCRIPTION
This prevent the error message "Cannot read property 'destroy' of undefined" when typing and deleting characters