### PR TITLE
Fix `contains` deprecation warning after Ember 2.8 upgrade

### DIFF
--- a/addon/components/slack-search-input/modifiers/-date/adapter.js
+++ b/addon/components/slack-search-input/modifiers/-date/adapter.js
@@ -23,7 +23,7 @@ export default {
       return moment().startOf('day').subtract(1, 'day');
     } else if (val === 'today') {
       return moment().startOf('day');
-    } else if (MONTHS.contains(val)) {
+    } else if (MONTHS.includes(val)) {
       return moment().month(val).startOf('month');
     } else if (DATE_FORMAT_FULL.test(val)) {
       return moment(val, 'YYYY-MM-DD:HH-mm');
@@ -35,7 +35,7 @@ export default {
   validate(string) {
     return string === 'yesterday' ||
       string === 'today' ||
-      MONTHS.contains(string) ||
+      MONTHS.includes(string) ||
       DATE_FORMAT.test(string) && moment(string, 'YYYY-MM-DD').isValid() ||
       DATE_FORMAT_FULL.test(string) && moment(string, 'YYYY-MM-DD:HH-mm').isValid();
   },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "6.1.3",
     "ember-helpers-array-contains": "^1.0.0",
+    "ember-runtime-enumerable-includes-polyfill": "^2.0.0",
     "ember-truth-helpers": "^1.2.0",
     "moment": "~2.12.0",
     "eonasdan-bootstrap-datetimepicker": "~4.17.37"


### PR DESCRIPTION
To replicate, use the before/after modifiers and select a date and search.

There were two Enumerable#contains that[ I changed to includes](https://emberjs.com/deprecations/v2.x/#toc_enumerable-contains) and added the polyfill in order to maintain backwards compatibility. I wasn't able to run the tests as it froze when I tried doing `ember test`  so appreciate any input in this regard.

Full message is 
```
DEPRECATION:Enumerable#containsis deprecated, useEnumerable#includesinstead. [deprecation id: ember-runtime.enumerable-contains] See http://emberjs.com/deprecations/v2.x#toc_enumerable-contains for more details.
```